### PR TITLE
go easy on 64-bit division

### DIFF
--- a/src/Pit8253.h
+++ b/src/Pit8253.h
@@ -74,6 +74,8 @@ class Pit8253Counter : public EmuObject //PassiveDevice
         int m_tempSumOut = 0;
         int m_tempAddOutClocks = 0;
 
+        uint32_t m_prevFastClock = 0;
+
         int m_mode;
         bool m_gate;
         bool m_out;


### PR DESCRIPTION
Проблема в том, что на rpi3 64-битное деление получается очень медленным и в текущем состоянии код тратит все свое время внутри Pit8253Counter::updateState().

С этим патчем эмулятор на rpi3 справляется с гигаскрин-демо в 50% одного ядра.