### PR TITLE
 Fix "this statement may fall through" gcc warnings. 

### DIFF
--- a/src/Cpu8080.cpp
+++ b/src/Cpu8080.cpp
@@ -299,6 +299,7 @@ int Cpu8080::i8080_execute(int opcode) {
                 g_emulation->debugRequest(this);
                 break;
             }
+            /* Falls through. */
         case 0x00:            /* nop */
             cpu_cycles = 4;
             break;
@@ -1285,6 +1286,7 @@ int Cpu8080::i8080_execute(int opcode) {
                 g_emulation->debugRequest(this);
                 break;
             }
+            /* Falls through. */
         case 0xC3:            /* jmp addr */
             cpu_cycles = 10;
             PC = RD_WORD(PC);
@@ -1331,6 +1333,7 @@ int Cpu8080::i8080_execute(int opcode) {
                 g_emulation->debugRequest(this);
                 break;
             }
+            /* Falls through. */
         case 0xC9:            /* ret */
             cpu_cycles = 10;
             POP(PC);
@@ -1364,6 +1367,7 @@ int Cpu8080::i8080_execute(int opcode) {
                 g_emulation->debugRequest(this);
                 break;
             }
+            /* Falls through. */
         case 0xCD:            /* call addr */
             cpu_cycles = 17;
             CALL;

--- a/src/Fdc1793.cpp
+++ b/src/Fdc1793.cpp
@@ -250,6 +250,7 @@ uint8_t Fdc1793::readByte(int addr)
                 case 7:
                 case 0xD:
                     m_status = m_track == 0 ? 0x24 : 0x20;
+                    /* Falls through. */
                 case 8:
                 case 9:
                     if (m_dma && m_accessMode == FAM_READING) {

--- a/src/RkSdController.cpp
+++ b/src/RkSdController.cpp
@@ -429,6 +429,7 @@ bool RkSdController::cmdLseek()
     case 101:
     case 102:
         createErrorAnswer(ERR_INVALID_COMMAND);
+        /* Falls through. */
     default:
         if (mode == 0)
             m_filePos = offset;


### PR DESCRIPTION
https://developers.redhat.com/blog/2017/03/10/wimplicit-fallthrough-in-gcc-7/